### PR TITLE
 Adiciona highlight para destacar proposições em pauta

### DIFF
--- a/src/components/EnergyGraphic.vue
+++ b/src/components/EnergyGraphic.vue
@@ -131,31 +131,31 @@ export default {
               color: color
             },
             encoding: {
-               x: {
-                 field: 'periodo',
-                 type: 'temporal',
-                 format: '%Y-%m-%d',
-                 scale: {
-                   type: 'utc'
-                 },
-                 axis: {
-                   title: '',
-                   grid: false,
-                   ticks: false,
-                   labels: false
-                 }
-               },
-               y: {
-                 field: 'energia_dia',
-                 type: 'quantitative',
-                 axis: {
-                   title: '',
-                   grid: false,
-                   labels: false,
-                   ticks: false
-                 }
-               },
-               size: {'value': 80}
+              x: {
+                field: 'periodo',
+                type: 'temporal',
+                format: '%Y-%m-%d',
+                scale: {
+                  type: 'utc'
+                },
+                axis: {
+                  title: '',
+                  grid: false,
+                  ticks: false,
+                  labels: false
+                }
+              },
+              y: {
+                field: 'energia_dia',
+                type: 'quantitative',
+                axis: {
+                  title: '',
+                  grid: false,
+                  labels: false,
+                  ticks: false
+                }
+              },
+              size: {'value': 80}
             }
           },
           {

--- a/src/components/ProposicaoItem.vue
+++ b/src/components/ProposicaoItem.vue
@@ -1,6 +1,6 @@
 <template>
     <el-card shadow="hover" class="box-card" :body-style= "highlight()">
-        <el-row class="em-pauta">
+        <el-row>
             <el-col :span="6">
                <!--  <router-link :to="{ name: 'proposicaoDetails', params: { casa: prop.casa, idExt: prop.id_ext }}"> -->
                 {{ prop.apelido }}
@@ -45,9 +45,9 @@ export default {
     date: Date
   },
   methods: {
-    highlight() {
+    highlight () {
       if (this.prop.em_pauta) {
-        return "border: 2px solid #ffec00"
+        return 'border: 2px solid #ffec00'
       }
     }
   }

--- a/src/components/ProposicaoItem.vue
+++ b/src/components/ProposicaoItem.vue
@@ -1,6 +1,6 @@
 <template>
-    <el-card shadow="hover" class="box-card">
-        <el-row>
+    <el-card shadow="hover" class="box-card" :body-style= "highlight()">
+        <el-row class="em-pauta">
             <el-col :span="6">
                <!--  <router-link :to="{ name: 'proposicaoDetails', params: { casa: prop.casa, idExt: prop.id_ext }}"> -->
                 {{ prop.apelido }}
@@ -43,6 +43,13 @@ export default {
     prop: Object,
     visId: String,
     date: Date
+  },
+  methods: {
+    highlight() {
+      if (this.prop.em_pauta) {
+        return "border: 2px solid #ffec00"
+      }
+    }
   }
 }
 </script>
@@ -73,15 +80,12 @@ export default {
 a {
   text-decoration: none;
 }
-
 #tags {
   display: flex;
 }
-
 .el-tag {
   margin-right: 3px;
 }
-
 .sigla {
   display: block;
   font-size: 12px;


### PR DESCRIPTION
- Não consegui adicionar o estilo no CSS, o element ui dificulta a alteração do estilo de seus componentes. Usei a propriedade ```body-style``` do el-card.
- Nenhuma proposição está em pauta, então não dará para ver o destaque. Para visualizar o destaque remova esta linha:
https://github.com/analytics-ufcg/agora-digital-frontend/pull/53/files#diff-59f82d71797964c90268b6b81b970c5cR49