### PR TITLE
Mostra fases futuras no progresso

### DIFF
--- a/src/components/card/collapsed/Fases.vue
+++ b/src/components/card/collapsed/Fases.vue
@@ -18,15 +18,16 @@ export default {
   methods: {
     geraEstilo (fase) {
       return {
-        'faseConcluida': this.isFaseConcluida(fase)
+        'faseConcluida': this.isFaseConcluida(fase),
+        'jumpedFase': this.isJumpedFase(fase)
       }
     },
     isFaseConcluida (fase) {
       return fase.data_fim
     },
-    jumpedFase (fase) {
-      const now = Date.now()
-      return new Date(fase.data_fim) < now
+
+    isJumpedFase (fase) {
+      return fase.pulou
     }
   },
   computed: {
@@ -63,9 +64,13 @@ export default {
     position: relative;
 }
 
-.cerrilhado {
-    background: repeating-linear-gradient(-45deg, white, white 2px, tomato 0, tomato 4px);
-    display: block;
+.jumpedFase {
+  background: none;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #DC6060;
+  width: 10px;
+  height: 10px;
 }
 
 .faseConcluida {

--- a/src/components/card/expanded/FasesProgress.vue
+++ b/src/components/card/expanded/FasesProgress.vue
@@ -49,7 +49,7 @@ export default {
         'inProgress': this.isInProgress(fase),
         'senado': fase.local_casa === 'senado',
         'camara': fase.local_casa === 'camara',
-        'planalto': fase.local === 'Plenário' && fase.local_casa === 'congresso',
+        'planalto': fase.local_casa === 'presidência da república' || fase.local_casa === 'congresso',
         'selectedFase': i === this.selectedFase
       }
     },
@@ -64,18 +64,11 @@ export default {
     },
 
     isJumpedFase (fase) {
-      const numberOfFases = this.sortedFases.length
-      let index = this.sortedFases.indexOf(fase)
-      if (this.isFinished(fase)) { return false }
-      for (let j = index + 1; j < numberOfFases; j++) {
-        if (this.isFinished(this.sortedFases[j])) { return true }
-      }
-
-      return false
+      return fase.pulou
     },
 
     isFuture (fase) {
-      return fase.data_fim == null && fase.data_inicio == null
+      return fase.data_fim == null && fase.data_inicio == null && !this.isJumpedFase(fase)
     }
   },
   computed: {
@@ -113,7 +106,7 @@ export default {
       text-transform: uppercase;
       color: black;
   }
-  // os before fazem as linhas, e os after os circulos
+  // --- os before fazem as linhas, e os after os circulo ---
 
   .progressbar li:before {
       width: 30px;
@@ -126,6 +119,10 @@ export default {
       background-position: left;
       background-size: cover;
       transition: transform .2s;
+      border-style: solid;
+      border-width: 0.5px;
+      border-color: white;
+      border-radius: 50%;
   }
 
   .progressbar li:after { //linha
@@ -151,7 +148,8 @@ export default {
   }
 
   .future:before {
-    background-image: url('../../../assets/vazio.png');
+    opacity: 0.5;
+    filter: alpha(opacity=50);
   }
 
   .planalto:before {


### PR DESCRIPTION
Agora mostra as casas das fases futuras no progresso do collapse aberto, e a fase pulada no progresso da header.

Precisa dos dados utilizados analytics-ufcg/agora-digital-backend#42