### PR TITLE
Permite a pesquisa de um projeto ignorando acentuação

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -9,3 +9,8 @@ export function resumirFases (fases) {
     return fases.filter(fase => fase.fase_global.indexOf('II') === -1)
   }
 }
+
+// Remove os acentos de uma palavra de entrada e retorna o resultado (palavra sem acentos)
+export function removeAcentos (word) {
+  return word.normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+}

--- a/src/views/Proposicoes.vue
+++ b/src/views/Proposicoes.vue
@@ -30,6 +30,7 @@
 <script>
 import ProposicaoItem from '@/components/card/ProposicaoItem'
 import { mapState, mapActions, mapGetters, mapMutations } from 'vuex'
+import { removeAcentos } from '@/utils'
 
 export default {
   name: 'proposicoes',
@@ -113,9 +114,8 @@ export default {
       return emPauta ? this.filter.emPautaFilter.some(options => options.status) : true
     },
     checkApelidoFilter (prop) {
-      const apelido = prop.apelido.toLowerCase()
-      const filtro = this.filter.nomeProposicaoFilter.nomeProposicao.toLowerCase()
-
+      const apelido = removeAcentos(prop.apelido.toLowerCase())
+      const filtro = removeAcentos(this.filter.nomeProposicaoFilter.nomeProposicao.toLowerCase())
       return apelido.match(filtro)
     },
     checkPropMatchesFilter (prop) {


### PR DESCRIPTION
O objetivo é facilitar a pesquisa do usuário e não deixá-la tão restritiva (acentuação).